### PR TITLE
Mesh updates, see comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 heroku-integration-service-mesh
+coverage.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+heroku-integration-service-mesh

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ lint: ## run go linters
 
 .PHONY: test
 test: ## run all of the test cases
-	$(Q) go test -cover ./...
+	$(Q) go test ./... -coverpkg=./... -coverprofile ./coverage.out
+	go tool cover -func ./coverage.out
 
 .PHONY: fmt
 fmt: ## run go fmt on all source files

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module main
 go 1.22.1
 
 require (
+	github.com/cbrewster/slog-env v0.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/go-chi/chi/v5 v5.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cbrewster/slog-env v0.1.1 h1:39ZC4aD/58MmSmIcIvYXJ98Fg98u0shTSckQh30ZMcw=
+github.com/cbrewster/slog-env v0.1.1/go.mod h1:iRBEHgaAW4KMBLuzOtHKJeQTjkZWk/ToEAjPR0ihv4c=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	slogenv "github.com/cbrewster/slog-env"
 	"github.com/urfave/cli/v2"
 	"log"
 	"log/slog"
@@ -16,9 +17,12 @@ func main() {
 
 	config := conf.GetConfig()
 
+	logger := slog.New(slogenv.NewHandler(slog.NewTextHandler(os.Stderr, nil)))
+	slog.SetDefault(logger)
+
 	app := &cli.App{
 		Name:                   "heroku-integration-service-mesh",
-		Usage:                  "Service to pass communication between Heroku Integration and Customer App",
+		Usage:                  "Service that handles validation and authentication between clients and Heroku apps",
 		UseShortOptionHandling: true,
 		Version:                fmt.Sprintf("%s [os: %s arch: %s]", VERSION, runtime.GOOS, runtime.GOARCH),
 		Action:                 startServer,

--- a/mesh/routes.go
+++ b/mesh/routes.go
@@ -47,6 +47,18 @@ func getForwardUrl(r *http.Request, appPort string) (string, error) {
 	return url, nil
 }
 
+/**
+ * Intercepts Heroku Integration app API requests validating and authenticating
+ * each request based on type - Salesforce or Data Action Target.
+ *
+ * For validation rules, see ValidateRequest.
+ *
+ * Requests are authenticated with the app's associated Heroku Integration add-on
+ * resource.
+ *
+ * If validation and authentication are successful, the mesh forwards the request
+ * to the target app API.
+ */
 func (routes *Routes) Pass() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()

--- a/mesh/routes.go
+++ b/mesh/routes.go
@@ -42,7 +42,7 @@ func NewRoutes() *Routes {
 }
 
 func getForwardUrl(r *http.Request, appPort string) (string, error) {
-	url := fmt.Sprintf("http://127.0.0.1:%s%s", appPort, r.URL.Path)
+	url := fmt.Sprintf("http://127.0.0.1:%s%s", appPort, r.URL.RequestURI())
 	return url, nil
 }
 
@@ -57,26 +57,26 @@ func getForwardUrl(r *http.Request, appPort string) (string, error) {
 // If validation and authentication are successful, the mesh forwards the request
 // to the target app API.
 func (routes *Routes) Pass() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(incomingRespWriter http.ResponseWriter, incomingReq *http.Request) {
 		config := conf.GetConfig()
 		should_auth_disable := os.Getenv("HEROKU_INTEGRATION_SERVICE_MESH_AUTH_DISABLE")
 		bypass_auth, err := strconv.ParseBool(should_auth_disable)
 
 		// Get requestID from heahder; if not found, generate and set
-		requestID := r.Header.Get(HdrNameRequestID)
+		requestID := incomingReq.Header.Get(HdrNameRequestID)
 		if requestID == "" {
 			requestID = uuid.New().String()
-			w.Header().Set(HdrNameRequestID, requestID)
+			incomingRespWriter.Header().Set(HdrNameRequestID, requestID)
 			logWarn(requestID, HdrNameRequestID+" not found! Generated and set "+requestID)
 		}
 		defer timeTrack(requestID, time.Now(), "Heroku Integration Service Mesh")
 
 		// Log request
-		apiPath := r.URL.Path
+		apiPath := incomingReq.URL.Path
 		logInfo(requestID, "Processing request to API "+apiPath+"...")
 
 		// Validate request headers
-		requestHeader, err := ValidateRequest(requestID, r.Header)
+		requestHeader, err := ValidateRequest(requestID, incomingReq.Header)
 		if err != nil {
 			httpStatusCode := http.StatusUnauthorized
 			switch err.(type) {
@@ -85,7 +85,15 @@ func (routes *Routes) Pass() http.HandlerFunc {
 			default:
 			}
 			logError(requestID, err.Error())
-			http.Error(w, err.Error(), httpStatusCode)
+			http.Error(incomingRespWriter, err.Error(), httpStatusCode)
+			return
+		}
+
+		// Get the request body from the incoming request
+		incomingReqBody, err := io.ReadAll(incomingReq.Body)
+		if err != nil {
+			logError(requestID, "Error parsing body from the request: "+err.Error())
+			http.Error(incomingRespWriter, err.Error(), http.StatusForbidden)
 			return
 		}
 
@@ -112,7 +120,7 @@ func (routes *Routes) Pass() http.HandlerFunc {
 				status, err := callSalesforceAuth(requestID, authRequestBody, config.IntegrationUrl, config.InvocationToken)
 				if err != nil {
 					logError(requestID, "Error authorizing Salesforce request: "+err.Error())
-					http.Error(w, err.Error(), http.StatusUnauthorized)
+					http.Error(incomingRespWriter, err.Error(), http.StatusUnauthorized)
 					return
 				}
 				finalStatus = status
@@ -121,15 +129,7 @@ func (routes *Routes) Pass() http.HandlerFunc {
 				logInfo(requestID, "Found Data Action Target request")
 
 				// Get data from query params
-				queryParams := r.URL.Query()
-
-				// Get the request body from the initial request
-				bodyStr, err := io.ReadAll(r.Body)
-				if err != nil {
-					logError(requestID, "Error parsing body from the request: "+err.Error())
-					http.Error(w, err.Error(), http.StatusForbidden)
-					return
-				}
+				queryParams := incomingReq.URL.Query()
 
 				// Build Data Action Target authentication request Body
 				orgId = queryParams.Get(OrgIdQueryParm)
@@ -137,7 +137,7 @@ func (routes *Routes) Pass() http.HandlerFunc {
 					ApiName:   queryParams.Get(ApiNameQueryParam),
 					OrgID:     orgId,
 					Signature: requestHeader.XSignature,
-					Payload:   string(bodyStr),
+					Payload:   string(incomingReqBody),
 				}
 				unauthorizedMsg = "Org " + orgId + " not found or not connected to app and/or Data Action Target '" +
 					dataActionTargetAuthRequestBody.ApiName + "' signed key not found or is invalid"
@@ -146,7 +146,7 @@ func (routes *Routes) Pass() http.HandlerFunc {
 				status, err := callDataTargetActionAuth(requestID, dataActionTargetAuthRequestBody, config.IntegrationUrl)
 				if err != nil {
 					logError(requestID, "Error authenticating Data Action Target request: "+err.Error())
-					http.Error(w, err.Error(), status)
+					http.Error(incomingRespWriter, err.Error(), status)
 					return
 				}
 
@@ -162,49 +162,52 @@ func (routes *Routes) Pass() http.HandlerFunc {
 				} else {
 					logError(requestID, "Failed Integration authentication request: "+strconv.Itoa(finalStatus))
 				}
-				http.Error(w, http.StatusText(finalStatus), finalStatus)
-				w.WriteHeader(finalStatus)
+				http.Error(incomingRespWriter, http.StatusText(finalStatus), finalStatus)
+				incomingRespWriter.WriteHeader(finalStatus)
 				return
 			}
 		} else {
 			logWarn(requestID, "Bypassed authentication")
 		}
 
+		// Successful auth'd!
 		logInfo(requestID, "Authenticated request!")
 
-		// Successful auth'd, forward request to API
-		forwardApiUrl, err := getForwardUrl(r, config.AppPort)
+		// Forward request to target API
+		forwardApiUrl, err := getForwardUrl(incomingReq, config.AppPort)
 		logInfo(requestID, "Forwarding request to app API "+forwardApiUrl)
-		forwardReq, err := http.NewRequest(r.Method, forwardApiUrl, r.Body)
+		forwardReq, err := http.NewRequest(incomingReq.Method, forwardApiUrl, bytes.NewReader(incomingReqBody))
 		if err != nil {
 			logError(requestID, "Error assembling request: "+err.Error())
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(incomingRespWriter, err.Error(), http.StatusBadRequest)
 		}
 
 		// Apply request headers to forward request
-		for header, values := range r.Header {
+		for header, values := range incomingReq.Header {
 			for _, value := range values {
 				forwardReq.Header.Set(header, value)
 			}
 		}
 
+		// Forward request
 		client := &http.Client{}
-		resp, err := client.Do(forwardReq)
+		forwardResp, err := client.Do(forwardReq)
 		if err != nil {
 			logError(requestID, "Error forwarding request: "+err.Error())
-			http.Error(w, "Error forwarding request "+requestID, http.StatusBadGateway)
+			http.Error(incomingRespWriter, "Error forwarding request "+requestID, http.StatusBadGateway)
 		}
 
-		defer resp.Body.Close()
-
-		for header, values := range resp.Header {
+		// Copy incoming headers to forward request
+		for header, values := range forwardResp.Header {
 			for _, value := range values {
-				w.Header().Add(header, value)
+				incomingRespWriter.Header().Add(header, value)
 			}
 		}
 
-		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+		// Copy forward request to incoming response
+		incomingRespWriter.WriteHeader(forwardResp.StatusCode)
+		io.Copy(incomingRespWriter, forwardResp.Body)
+		defer forwardResp.Body.Close()
 	}
 }
 

--- a/mesh/utils.go
+++ b/mesh/utils.go
@@ -1,0 +1,20 @@
+package mesh
+
+import (
+	"log/slog"
+	"time"
+)
+
+func logInfo(requestID string, msg string) {
+	slog.Info(msg, "source", "heroku-integration-service-mesh", "request-id", requestID)
+}
+
+// TODO: Combine w/ logInfo and dynamically call appropriate log level func
+func logError(requestID string, msg string) {
+	slog.Error(msg, "source", "heroku-integration-service-mesh", "request-id", requestID)
+}
+
+func timeTrack(requestID string, startTime time.Time, name string) {
+	elapsedTime := time.Since(startTime)
+	logInfo(requestID, name+" took "+elapsedTime.String())
+}

--- a/mesh/utils.go
+++ b/mesh/utils.go
@@ -30,5 +30,5 @@ func logError(requestID string, msg string) {
 
 func timeTrack(requestID string, startTime time.Time, name string) {
 	elapsedTime := time.Since(startTime)
-	logInfo(requestID, name+" took "+elapsedTime.String())
+	logDebug(requestID, name+" took "+elapsedTime.String())
 }

--- a/mesh/utils.go
+++ b/mesh/utils.go
@@ -5,8 +5,22 @@ import (
 	"time"
 )
 
+const (
+	HdrNameRequestID = "x-request-id"
+)
+
 func logInfo(requestID string, msg string) {
 	slog.Info(msg, "source", "heroku-integration-service-mesh", "request-id", requestID)
+}
+
+// TODO: Combine w/ logInfo and dynamically call appropriate log level func
+func logDebug(requestID string, msg string) {
+	slog.Debug(msg, "source", "heroku-integration-service-mesh", "request-id", requestID)
+}
+
+// TODO: Combine w/ logInfo and dynamically call appropriate log level func
+func logWarn(requestID string, msg string) {
+	slog.Warn(msg, "source", "heroku-integration-service-mesh", "request-id", requestID)
 }
 
 // TODO: Combine w/ logInfo and dynamically call appropriate log level func

--- a/mesh/validator.go
+++ b/mesh/validator.go
@@ -75,25 +75,24 @@ type RequestHeader struct {
 	IsSalesforceRequest bool            `json:"isDataActionTargetRequest"`
 }
 
-/*
-*
-  - Validate the request headers.
-    *
-  - Salesforce request required headers:
-  - x-request-id
-  - x-request-context
-  - x-client-context
-    *
-  - Data Action Target request required headers:
-  - x-signature
-    *
-  - @param requestID
-  - @param header
-  - @return
-  - @throws MeshValidationException
-  - @throws InvalidRequest
-  - @throws MalformedRequest
-*/
+/**
+ * Validate the request headers based on type - Salesforce or Data Action Target.
+ *
+ * Request Salesforce request headers:
+ *   - x-request-id
+ *   - x-request-context
+ *   - x-client-context
+ *
+ * Required Data Action Target request headers:
+ *   - x-signature
+ *
+ * @param requestID
+ * @param header
+ * @return
+ * @throws MeshValidationException
+ * @throws InvalidRequest
+ * @throws MalformedRequest
+ */
 func ValidateRequest(requestID string, header http.Header) (string, *RequestHeader, error) {
 	xRequestID := header.Get(HdrNameRequestID)
 
@@ -147,13 +146,13 @@ func ValidateRequest(requestID string, header http.Header) (string, *RequestHead
 		return requestID, nil, NewMalformedRequest("Invalid Salesforce x-request-context")
 	}
 
-	//ensure all values are present in request context
+	// ensure all values are present in request context
 	if err := validateRequestContextValues(requestID, &XRequestContext); err != nil {
 		logError(requestID, "Invalid request: unable to validate Salesforce x-request-context header: "+err.Error())
 		return requestID, nil, err
 	}
 
-	//validate that request is coming from an org
+	// validate that request is coming from an org
 	orgID := XRequestContext.OrgID
 	// TODO: Adjust once both requestId and orgId are both 18-char
 	truncatedOrgID := orgID[:len(orgID)-3]

--- a/test/validator_test.go
+++ b/test/validator_test.go
@@ -33,14 +33,14 @@ func convertContextToString(context *mesh.XRequestContext) string {
 }
 
 func TestValidateRequestSuccess(t *testing.T) {
-	header := http.Header{}
-	header.Set(mesh.HdrNameRequestID, MockRequestID)
-	header.Set(mesh.HdrRequestsContext, convertContextToString(MockValidXRequestContext))
-	header.Set(mesh.HdrClientContext, MockValidXRequestContext.ID)
+	headers := http.Header{}
+	headers.Set(mesh.HdrNameRequestID, MockRequestID)
+	headers.Set(mesh.HdrRequestsContext, convertContextToString(MockValidXRequestContext))
+	headers.Set(mesh.HdrClientContext, MockValidXRequestContext.ID)
 
-	requestID, validateRequestHeader, err := mesh.ValidateRequest(MockRequestID, header)
+	validateRequestHeader, err := mesh.ValidateRequest(MockRequestID, headers)
 
-	if requestID != MockRequestID {
+	if validateRequestHeader.XRequestID != MockRequestID {
 		t.Error("Should have requestID")
 	}
 
@@ -54,12 +54,11 @@ func TestValidateRequestSuccess(t *testing.T) {
 }
 
 func TestInvalidRequestID(t *testing.T) {
-	header := http.Header{}
-	header.Set(mesh.HdrNameRequestID, "INVALID-REQUEST-ID")
-	header.Set(mesh.HdrRequestsContext, convertContextToString(MockValidXRequestContext))
-	header.Set(mesh.HdrClientContext, MockValidXRequestContext.ID)
+	headers := http.Header{}
+	headers.Set(mesh.HdrRequestsContext, convertContextToString(MockValidXRequestContext))
+	headers.Set(mesh.HdrClientContext, MockValidXRequestContext.ID)
 
-	_, _, err := mesh.ValidateRequest(MockRequestID, header)
+	_, err := mesh.ValidateRequest("INVALID-REQUEST-ID", headers)
 
 	if err == nil {
 		t.Error("Expected error")
@@ -71,11 +70,11 @@ func TestInvalidRequestID(t *testing.T) {
 }
 
 func TestValidateRequestFailureMissingHeaderKey(t *testing.T) {
-	header := http.Header{}
-	header.Set(mesh.HdrNameRequestID, MockValidXRequestContext.OrgID)
-	header.Set(mesh.HdrRequestsContext, convertContextToString(MockValidXRequestContext))
+	headers := http.Header{}
+	headers.Set(mesh.HdrNameRequestID, MockValidXRequestContext.OrgID)
+	headers.Set(mesh.HdrRequestsContext, convertContextToString(MockValidXRequestContext))
 
-	_, _, err := mesh.ValidateRequest(MockRequestID, header)
+	_, err := mesh.ValidateRequest(MockRequestID, headers)
 
 	if err == nil {
 		t.Error("Expected error")
@@ -95,12 +94,12 @@ func TestValidateRequestFailureMissingContextKey(t *testing.T) {
 		OrgID:        uuid.New().String(),
 	}
 
-	header := http.Header{}
-	header.Set(mesh.HdrNameRequestID, MockValidXRequestContext.OrgID)
-	header.Set(mesh.HdrRequestsContext, convertContextToString(invalidXRequestContext))
-	header.Set(mesh.HdrClientContext, invalidXRequestContext.ID)
+	headers := http.Header{}
+	headers.Set(mesh.HdrNameRequestID, MockValidXRequestContext.OrgID)
+	headers.Set(mesh.HdrRequestsContext, convertContextToString(invalidXRequestContext))
+	headers.Set(mesh.HdrClientContext, invalidXRequestContext.ID)
 
-	_, _, err := mesh.ValidateRequest(MockRequestID, header)
+	_, err := mesh.ValidateRequest(MockRequestID, headers)
 	if err == nil {
 		t.Errorf("Expected 'missing value for x-requests-context: Resource' got %v", err)
 	}
@@ -108,12 +107,12 @@ func TestValidateRequestFailureMissingContextKey(t *testing.T) {
 }
 
 func TestIsDataActionTargetRequest(t *testing.T) {
-	header := http.Header{}
-	header.Set(mesh.HdrSignature, uuid.New().String())
+	headers := http.Header{}
+	headers.Set(mesh.HdrSignature, uuid.New().String())
 
-	requestID, validateRequestHeader, err := mesh.ValidateRequest(MockRequestID, header)
+	validateRequestHeader, err := mesh.ValidateRequest(MockRequestID, headers)
 
-	if requestID != MockRequestID {
+	if validateRequestHeader.XRequestID != MockRequestID {
 		t.Error("Should have requestID")
 	}
 

--- a/test/validator_test.go
+++ b/test/validator_test.go
@@ -10,10 +10,9 @@ import (
 	mesh "main/mesh"
 )
 
-
 var MockOrgID18 = "001Ws00003GGHVDIA5"
 var MockUUID = uuid.New().String()
-var MockRequestID =  MockOrgID18[:len(MockOrgID18)-3] + "-" + MockUUID
+var MockRequestID = MockOrgID18[:len(MockOrgID18)-3] + "-" + MockUUID
 var MockValidXRequestContext = &mesh.XRequestContext{
 	ID:           MockRequestID,
 	Auth:         "auth",

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package main
 
 // VERSION is the app-global version string, which should be substituted with a
 // real value during build.
-var VERSION = "v0.12.0"
+var VERSION = "v0.12.1"


### PR DESCRIPTION
Updates:
- `Datacloud` -> `Data Action Target` renames
- Data Action Target payload to string then to add-on auth API
- `x-request-id` also sent w/ DAT requests
- Verbose logging w/ `requestID`
- Adjusted HTTP status codes - `401` for wholesale invalid requests, `400` for incomplete requests
- Measure and log times: mesh interception, add-on API calls
- `GO_LOG` support to change log level
- More comments