### PR TITLE
Improve release mechanism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-    # change runner when using a public repo. See https://salesforce.quip.com/bu6UA0KImOxJ
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release New Version
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    # change runner when using a public repo. See https://salesforce.quip.com/bu6UA0KImOxJ
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate tar-gz
+        run: make tar-gz
+      - name: Cut new Github Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: heroku-integration-service-mesh.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
+.DS_Store
 heroku-integration-service-mesh.tar.gz
 coverage.out
+bin/**

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,6 @@ bin/%: $(SRC_FILES)
 	$(info $(M) building $@ …)
 	$(Q) $(CC) -o $@ github.com/heroku/heroku-integration-service-mesh
 
-release: | build ## run to generate and tar heroku-integration-service-mesh binary
+tar-gz: | build ## build and tar the binary
 	$(info $(M) tar heroku-integration-service-mesh ...)
 	$(Q) tar -zcvf heroku-integration-service-mesh.tar.gz -C bin heroku-integration-service-mesh

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,15 @@ bin/%: $(SRC_FILES)
 tar-gz: | build ## build and tar the binary
 	$(info $(M) tar heroku-integration-service-mesh ...)
 	$(Q) tar -zcvf heroku-integration-service-mesh.tar.gz -C bin heroku-integration-service-mesh
+
+release: ## create release tag and push to github to trigger release. Specify VERSION=vX.Y.Z and SHA=abcd123
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: Version must be specified. Usage: make release VERSION=vX.Y.Z SHA=1234abc"; \
+		exit 1; \
+	fi
+	@if [ -z "$(SHA)" ]; then \
+		echo "Error: commit SHA must be specified. Usage: make release VERSION=vX.Y.Z SHA=1234abc"; \
+		exit 1; \
+    fi
+	$(info $(M) create release tag and push to github to trigger release)
+	$(Q) scripts/release.sh $(VERSION) $(SHA)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SRC_FILES := $(shell find . -name '*.go')
 GO_MOD := $(go list -m)
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 PATH := $(ROOT_DIR)/bin:$(ROOT_DIR)/.local/bin:$(GOPATH)/bin:$(PATH)
-CC = env PATH=$(PATH) go build -ldflags '$(LD_FLAGS)'
+CC = env PATH=$(PATH) go build -ldflags '$(LD_FLAGS)' -trimpath
 
 # Formatting/Display
 Q:=$(if $(filter 1,$(VERBOSE)),,@)

--- a/conf/version.go
+++ b/conf/version.go
@@ -2,4 +2,4 @@ package conf
 
 // VERSION is the app-global version string, which should be substituted with a
 // real value during build.  Follows semantic versioning: MAJOR.MINOR.PATCH
-var VERSION = "v0.12.6"
+var VERSION = "v0.1.1"

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -71,22 +71,19 @@ time=2024-09-30T16:01:54.865-06:00 level=ERROR msg="400 Invalid request" app=loc
 
 ### Release
 
-1. Update `version.go` bumping up appropriate major, minor, or patch version.
-2. On [heroku/heroku-integration-service repo](https://github.com/heroku/heroku-integration-service-mesh/releases), follow [Create a release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) instructions to create a release.
-3. Run `make release` to build and generate `heroku-integration-service-mesh.tar.gz` tar file.
+1. Update `conf/version.go` bumping up appropriate major, minor, or patch version (vX.Y.Z) via PR.
+1. Once your PR is merged, switch to the main branch `git checkout main`. 
+1. Get the commit SHA of your merged PR on main.
+1. Run `make release VERSION=vX.Y.Z SHA=1234ab` This runs `scripts/release.sh` which contains some sanity checks. 
+1. Confirm that you want to proceed after sanity checks pass. The script creates and pushes a tag to the repo which triggers the Github Action in `.github/workflows/release.yml`.
 ```shell
-$ make release
-▶ formatting …
-▶ vetting …
-▶ testing …
-ok      command-line-arguments  0.009s
-▶ building bin/heroku-integration-service-mesh …
-▶ done
-▶ tar heroku-integration-service-mesh ...
-heroku-integration-service-mesh
-
-$ ls -l heroku-integration-service-mesh.tar.gz 
--rw-rw-r-- 1 cwall cwall 6.7M Sep 30 15:25 heroku-integration-service-mesh.tar.gz
+% make release VERSION=v0.0.3 SHA=1234abc
+▶ create release tag and push to github to trigger release
+All Pre-checks passed. Release version v0.0.3 at commit 1234abc? (y/N) y
+...
+To https://github.com/heroku/heroku-integration-service-mesh.git
+ * [new tag]         v0.0.3 -> v0.0.3
+Release v0.0.3 created on commit 1234abc and pushed successfully. Check https://github.com/heroku/heroku-integration-service-mesh/actions/workflows/release.yml for GH Action status.
 ```
-4. Upload `heroku-integration-service-mesh.tar.gz` as release artifact.
+
 5. Run buildpack locally to validate download and install.  See [Heroku Buildpack for Heroku Integration Service Mesh - Run Locally](https://github.com/heroku/heroku-buildpack-heroku-integration-service-mesh?tab=readme-ov-file#run-locally).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,9 +17,9 @@ if ! [[ $release_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
-# Ensure a SHA is provided
+# Ensure a commit SHA is provided
 if [[ -z "$sha" ]]; then
-    echo "Error: SHA must be provided."
+    echo "Error: commit SHA to tag against must be provided."
     exit 1
 fi
 
@@ -29,20 +29,20 @@ if ! grep -qc "var VERSION = \"$release_tag\"" conf/version.go; then
     exit 1
 fi
 
-# Ensure we are on the main branch
+# Ensure we are on the main branch since release is tagged on main
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$current_branch" != "main" ]]; then
     echo "Error: Must switch to main branch"
     exit 1
 fi
 
-# Ensure there are no local changes
+# Ensure there are no local changes to repo since direct commits to main is blocked.
 if ! git diff-index --quiet HEAD --; then
-    echo "Error: You have uncommitted changes. Please commit or stash them before proceeding."
+    echo "Error: You have uncommitted changes. Please commit to branch or stash them before proceeding."
     exit 1
 fi
 
-# Check if the tag already exists
+# Check if the release tag already exists
 if git rev-parse "$release_tag" >/dev/null 2>&1; then
     echo "Error: Tag $release_tag already exists in repo. Please use a new version number."
     exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+release_tag=$(echo "$1" | xargs)  # Trim whitespace
+sha=$(echo "$2" | xargs)  # Trim whitespace
+
+# Ensure a release tag is provided
+if [[ -z "$release_tag" ]]; then
+    echo "Usage: $0 vX.Y.Z <sha>"
+    exit 1
+fi
+
+# Ensure the tag follows vX.Y.Z format
+if ! [[ $release_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in format vX.Y.Z"
+    exit 1
+fi
+
+# Ensure a SHA is provided
+if [[ -z "$sha" ]]; then
+    echo "Error: SHA must be provided."
+    exit 1
+fi
+
+# Verify version in conf/version.go matches with version
+if ! grep -qc "var VERSION = \"$release_tag\"" conf/version.go; then
+    echo "Error: Version mismatch. Update conf/version.go to $release_tag via PR first"
+    exit 1
+fi
+
+# Ensure we are on the main branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$current_branch" != "main" ]]; then
+    echo "Error: Must switch to main branch"
+    exit 1
+fi
+
+# Ensure there are no local changes
+if ! git diff-index --quiet HEAD --; then
+    echo "Error: You have uncommitted changes. Please commit or stash them before proceeding."
+    exit 1
+fi
+
+# Check if the tag already exists
+if git rev-parse "$release_tag" >/dev/null 2>&1; then
+    echo "Error: Tag $release_tag already exists in repo. Please use a new version number."
+    exit 1
+fi
+
+# Ensure the provided SHA exists in the repository
+if ! git rev-parse --verify "$sha" >/dev/null 2>&1; then
+    echo "Error: Provided commit SHA does not exist in the repository."
+    exit 1
+fi
+
+# Confirm the release
+read -p "All Pre-checks passed. Release version $release_tag at commit $sha? (y/N) " confirm
+if [[ "$confirm" != "y" ]]; then
+    echo "Release aborted."
+    exit 1
+fi
+
+# Create and push the tag
+git tag -a "$release_tag" "$sha" -m "Release $release_tag on $sha"
+if ! git push origin "$release_tag"; then
+    echo "Error: Failed to push tag. Deleting local tag."
+    git tag -d "$release_tag"
+    exit 1
+fi
+
+echo "Release $release_tag created on $sha and pushed successfully. Check https://github.com/heroku/heroku-integration-service-mesh/actions/workflows/release.yml for release status."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,4 +69,4 @@ if ! git push origin "$release_tag"; then
     exit 1
 fi
 
-echo "Release $release_tag created on $sha and pushed successfully. Check https://github.com/heroku/heroku-integration-service-mesh/actions/workflows/release.yml for release status."
+echo "Release $release_tag created on commit $sha and pushed successfully. Check https://github.com/heroku/heroku-integration-service-mesh/actions/workflows/release.yml for GH Action status."


### PR DESCRIPTION
- Github Action created which is triggered when a tag is pushed on branch main. The Action builds a tar.gz file and cuts a new release.
- A script was added which triggers the GH Action after some validation.
- Makefile was updated by adding a new target to trigger the script.
- Also fixed the issue with full paths showing in the stacktraces.

This was developed and tested on a private repo to avoid creating unnecessary tags/releases in this repo. 
I still need to test the GH Action on this repo once the PR is approved and merged.

Work Item: [W-17404850](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026aYSHYA2/view)