### PR TITLE
Use an IP Allow Listed Runner per #heroku-hipe-help

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix bug with GH Action related to using the wrong GHA runner #25

Context: https://salesforce-internal.slack.com/archives/C07TFBYRJCR/p1739309586993179
 