### PR TITLE
Validate response after forwarding request to application

### DIFF
--- a/conf/version.go
+++ b/conf/version.go
@@ -2,4 +2,4 @@ package conf
 
 // VERSION is the app-global version string, which should be substituted with a
 // real value during build.  Follows semantic versioning: MAJOR.MINOR.PATCH
-var VERSION = "v0.1.1"
+var VERSION = "v0.1.2"

--- a/mesh/proxy.go
+++ b/mesh/proxy.go
@@ -353,8 +353,13 @@ func ForwardRequestReplyToIncomingRequest(
 	// Log time took to evaluate request and forward to API
 	TimeTrack(requestID, startTime, "Heroku Integration Service Mesh")
 
-	// Copy API's response to incoming response
-	ReplyToIncomingRequest(requestID, forwardResp, incomingRespWriter)
+	// If the request failed to be forwarded to the application, the ForwardRequest function below
+	// will have already written the error to incomingRespWriter. In that scenario, forwardResp
+	// will be nil, so we can just ignore it
+	if forwardResp != nil {
+		// Copy API's response to incoming response
+		ReplyToIncomingRequest(requestID, forwardResp, incomingRespWriter)
+	}
 }
 
 // ForwardRequest Forward request to target API


### PR DESCRIPTION
When testing this locally, I ran my `helloWorld-integration` app at port 8080 and the Heroku App listening at port 8080, like this:

```
$ HEROKU_INTEGRATION_TOKEN=12345 \                                                                                                                 [23:27:43]
HEROKU_INTEGRATION_API_URL=http://localhost:3000 \
APP_PORT=8080 /.../heroku-integration-service-mesh/bin/heroku-integration-service-mesh \
heroku local -f Procfile.local -p 8080
```

That caused the service mesh to start, but not my application. When I sent the request to the service mesh, it tried to forward it to my application [here](https://github.com/heroku/heroku-integration-service-mesh/blob/5adbaaca30f6a7e1f94ab77a4f75f3a8f64413b6/mesh/proxy.go#L390), and that returned a nil response and an error. As we are already writing the error to `incomingRespWriter` I think it's safe to just ignore the response and return.