### PR TITLE
Get ApiURL from the env var based on AddonUUID from x-resource-context

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -18,6 +18,7 @@ const (
 	HerokuIntegrationSalesforceAuthPath       = "/invocations/authentication"
 	HerokuIntegrationDataActionTargetAuthPath = "/data_action_targets/authenticate"
 	YamlFileName                              = "heroku-integration-service-mesh.yaml"
+	AddonConnectionUrlFormat                  = "https://applink.heroku.com/addons/%s/connections/salesforce"
 )
 
 type Authentication struct {

--- a/mesh/validator.go
+++ b/mesh/validator.go
@@ -58,6 +58,7 @@ type XRequestContext struct {
 	Resource     string `json:"resource"`
 	Type         string `json:"type"`
 	AppUUID      string `json:"appUuid"`
+	AddonUUID    string `json:"addonUuid"`
 }
 
 type RequestHeader struct {

--- a/test/mesh/utils.go
+++ b/test/mesh/utils.go
@@ -3,6 +3,7 @@ package mesh
 import (
 	"encoding/base64"
 	"encoding/json"
+
 	"github.com/google/uuid"
 
 	"github.com/heroku/heroku-integration-service-mesh/mesh"
@@ -20,6 +21,7 @@ var MockValidXRequestContext = &mesh.XRequestContext{
 	Resource:     "resource",
 	Type:         "type",
 	AppUUID:      MockUUID,
+	AddonUUID:    MockUUID,
 }
 
 func ConvertContextToString(context *mesh.XRequestContext) string {


### PR DESCRIPTION
The AppLink addon will allow apps to attach multiple addons, the request should traverse the env vars and find the correct ApiURL to validate the requests coming from Salesforce and DataCloud

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Bz8RjYAJ/view