### PR TITLE
Increase code coverage

### DIFF
--- a/test/conf/config_test.go
+++ b/test/conf/config_test.go
@@ -25,6 +25,34 @@ func Test_GetConfigDefaults(t *testing.T) {
 	validateYamlConfigDefaults(t, config.YamlConfig)
 }
 
+func Test_GetConfigWithYaml(t *testing.T) {
+	t.Setenv("HEROKU_INTEGRATION_TOKEN", "HEROKU_INTEGRATION_TOKEN")
+	t.Setenv("HEROKU_INTEGRATION_API_URL", "HEROKU_INTEGRATION_API_URL")
+
+	config := conf.GetConfigWithYamlFile()
+
+	if config.Version == "" {
+		t.Error("Should have Version")
+	}
+
+	if config.PublicPort == "" {
+		t.Error("Should have PublicPort")
+	}
+
+	validateYamlConfigDefaults(t, config.YamlConfig)
+}
+
+func Test_Flags(t *testing.T) {
+	config := conf.GetConfig()
+	flags := config.Flags()
+	if len(flags) == 0 {
+		t.Error("Should have flags")
+	}
+	if len(flags) != 1 {
+		t.Errorf("Should have 1 string flags, but got %d", len(flags))
+	}
+}
+
 func Test_InitYamlConfig(t *testing.T) {
 	yamlConfig, err := conf.InitYamlConfig(conf.YamlFileName)
 

--- a/test/mesh/proxy_test.go
+++ b/test/mesh/proxy_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/heroku/heroku-integration-service-mesh/mesh"
 )
 
+func Test_NewRoutes(t *testing.T) {
+	// Create new routes
+	routes := mesh.NewRoutes()
+
+	// Verify routes is not nil
+	if routes == nil {
+		t.Error("Expected NewRoutes to return non-nil Routes struct")
+	}
+
+	// Verify the routes instance can be used (indirect way to verify it's properly constructed)
+	handler := routes.ServiceMesh()
+	if handler == nil {
+		t.Error("Expected Routes to provide a valid ServiceMesh handler")
+	}
+}
+
 func Test_ShouldBypassValidationAuthentication(t *testing.T) {
 	config := &conf.Config{
 		ShouldBypassAllRoutes: true,

--- a/test/mesh/utils_test.go
+++ b/test/mesh/utils_test.go
@@ -3,6 +3,7 @@ package mesh
 import (
 	"encoding/base64"
 	"encoding/json"
+
 	"github.com/google/uuid"
 
 	"github.com/heroku/heroku-integration-service-mesh/mesh"

--- a/test/mesh/validator_test.go
+++ b/test/mesh/validator_test.go
@@ -1,9 +1,10 @@
 package mesh
 
 import (
-	"github.com/google/uuid"
 	"net/http"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/heroku/heroku-integration-service-mesh/mesh"
 )


### PR DESCRIPTION
Adding a couple more tests, taking us to 81.7% should get us compliant for Production Readiness

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002DOG1lYAH/view
W-18355923





Current coverage run:

```dasofiei@dasofie-ltmjdgv heroku-integration-service-mesh % go tool cover -func ./coverage.out
github.com/heroku/heroku-integration-service-mesh/conf/config.go:59:            Flags                                   100.0%
github.com/heroku/heroku-integration-service-mesh/conf/config.go:103:           InitYamlConfig                          91.3%
github.com/heroku/heroku-integration-service-mesh/conf/config.go:147:           GetConfig                               100.0%
github.com/heroku/heroku-integration-service-mesh/conf/config.go:151:           GetConfigWithYamlFile                   100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:37:             InitializeRoutes                        100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:42:             NewRoutes                               100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:46:             GetForwardUrl                           100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:61:             ServiceMesh                             52.8%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:132:            ShouldBypassValidationAuthentication    100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:163:            ValidateRequestHandler                  100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:181:            AuthenticateRequest                     62.2%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:267:            InvokeSalesforceAuth                    100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:280:            InvokeDataTargetActionAuth              100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:293:            InvokeHerokuIntegrationService          80.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:345:            ForwardRequestReplyToIncomingRequest    100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:368:            ForwardRequest                          87.5%
github.com/heroku/heroku-integration-service-mesh/mesh/proxy.go:407:            ReplyToIncomingRequest                  87.5%
github.com/heroku/heroku-integration-service-mesh/mesh/utils.go:12:             LogInfo                                 100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/utils.go:17:             LogDebug                                100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/utils.go:22:             LogWarn                                 100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/utils.go:27:             LogError                                100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/utils.go:31:             TimeTrack                               100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:26:         HttpStatusCode                          100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:30:         Error                                   100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:35:         NewInvalidRequest                       100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:45:         NewMalformedRequest                     100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:81:         ValidateRequest                         85.7%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:161:        doSalesforceHeadersExist                100.0%
github.com/heroku/heroku-integration-service-mesh/mesh/validator.go:178:        validateRequestContextValues            100.0%
total:                                                                          (statements)                            81.6%