### PR TITLE
add coverage workflow PR 1/2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+name: Coverage Threshold
+on:
+  workflow_dispatch:
+    inputs:
+      coverage_threshold:
+        description: 'Coverage threshold'
+        required: true
+        default: "80"
+      coverage:
+        description: 'Coverage'
+        required: true
+        default: "0"
+
+jobs:
+  coverage-threshold:
+    runs-on: sfdc-hk-ubuntu-latest
+    steps:
+    - name: Coverage Threshold
+      run: |
+        if (( $COVERAGE < $COVERAGE_THRESHOLD ))
+        then
+          echo "$COVERAGE is below threshold of $COVERAGE_THRESHOLD"
+          exit 1
+        fi
+        echo "$COVERAGE meets threshold of $COVERAGE_THRESHOLD"
+        exit 0
+      env:
+        COVERAGE_THRESHOLD: ${{ github.event.inputs.coverage_threshold }}
+        COVERAGE: ${{ github.event.inputs.coverage }}


### PR DESCRIPTION
Adding coverage workflow for this repository as part of Production Readiness.

Same changes have been applied to hemp-creds here:
PR1: https://github.com/heroku/hemp-creds/pull/213
PR2: https://github.com/heroku/hemp-creds/pull/210

Will follow the same release mechanism, 2 PRs.

W-18391391